### PR TITLE
2.0.7: Hotfix for random API crashes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -23,5 +23,5 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.0.6"
+    CURRENT_VERSION = "2.0.7"
     API_LAST_UPDATE_TIME = os.path.getmtime(r'app/main.py')

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -19,14 +19,17 @@
               usa-prose usa-layout-docs
             " id="main-content">
             <h1>Metro API v{{api_version}}</h1>
-            <div class="usa-alert usa-alert--info usa-alert--slim">
-              <div class="usa-alert__body">
-                <p class="usa-alert__text">
-                  <b>Last updated: {{update_time}}</b>
-                  <span id="last_updated_label"></span>
-                </p>
+            {% if update_time != None %}
+              <div class="usa-alert usa-alert--info usa-alert--slim">
+                <div class="usa-alert__body">
+                  <p class="usa-alert__text">
+                    <b>Last updated: {{update_time}}</b>
+                    <span id="last_updated_label"></span>
+                  </p>
+                </div>
               </div>
-            </div>
+            {% endif %}
+
   
             <p class="usa-intro">
               Welcome to the Metro API.  This API currently provides access to the following data:

--- a/app/main.py
+++ b/app/main.py
@@ -300,8 +300,12 @@ def login(request:Request):
 def index(request:Request):
     logger.info("GET /")
     # test_logging()
-    default_update = datetime.fromtimestamp((Config.API_LAST_UPDATE_TIME)).astimezone(pytz.timezone("America/Los_Angeles"))
-    human_readable_default_update = default_update.strftime('%Y-%m-%d %H:%M')
+    human_readable_default_update = None
+    try:
+        default_update = datetime.fromtimestamp((Config.API_LAST_UPDATE_TIME)).astimezone(pytz.timezone("America/Los_Angeles"))
+        human_readable_default_update = default_update.strftime('%Y-%m-%d %H:%M')
+    except Exception as e:
+        logger.exception(type(e).__name__ + ": " + str(e), exc_info=False)
     return templates.TemplateResponse("index.html", context= {"request": request,"api_version":Config.CURRENT_VERSION,"update_time":human_readable_default_update})
 
 def test_logging():

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,11 @@
 # Metro API v2
 Metro API v2 is an API for Metro's GTFS-RT data.
 
+## Versioning
+
+Metro API v2 uses a modified version of [Semantic Versioning](https://semver.org/), with major (`X`), minor(`x`), and hotfix(`*`) releases for the numbers respectively: `X.x.*`.
+
+More versioning information can be found in [versioning.md](versioning.md)
 ## Getting started
 
 ### Prerequistes

--- a/versioning.md
+++ b/versioning.md
@@ -1,0 +1,30 @@
+(2.0.4)
+2.0.0
+
+Branches --> Image:
+- main (v2.0.4) --> metro-api-v2:2.0
+- dev  (v2.0.5) --> metro-api-v2:2.0-dev
+  dev  (v2.0.50)
+
+"Early Access" Release: 2.1.0 (2.0.50)
+
+- main (v2.1.0) --> metro-api-v2:2.1
+- dev  (v2.1.1) --> metro-api-v2:2.1-dev
+
+"Full" Release: 2.2.0 (2.1.50)
+
+
+-----------------
+
+MVP Release: 2.0.0
+- main (v2.0.0) --> metro-api-v2:2.0
+
+"Early Access" Release: 2.1.0
+- dev  (v2.1.0) --> metro-api-v2:2.1-dev
+  dev  (v2.1.0)
+- main (v2.1.0) --> metro-api-v2:2.1
+  hotfix (v2.1.1)
+
+"Full" Release: 2.2.0
+- dev  (v2.2.0) --> metro-api-v2:2.2-dev
+- main (v2.2.0) --> metro-api-v2:2.2


### PR DESCRIPTION
This hotfix prevents random crashing of the API and closes #35 
### Change log

- added `versioning.md`
#### app/main.py
- moved the `update_time` to a try-statement

#### app/frontend/index.html
- added `if-block` statement to not show update time if it is blank

#### readme.md
- information about versioning