### PR TITLE
fix datetime typeerror issue

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -22,7 +22,7 @@ class Config:
     REMOTEPATH = '/nextbus/prod/'
     DEBUG = True
     REPODIR = "/gtfs_rail"
-    CURRENT_VERSION = "2.0.11"
+    CURRENT_VERSION = "2.0.12"
     API_LAST_UPDATE_TIME = os.path.getmtime(r'app/main.py')
     LOGZIO_TOKEN = os.environ.get('LOGZIO_TOKEN')
     LOGZIO_URL = os.environ.get('LOGZIO_URL')

--- a/app/main.py
+++ b/app/main.py
@@ -280,7 +280,8 @@ def login(request:Request):
 def index(request:Request):
     human_readable_default_update = None
     try:
-        default_update = datetime.fromtimestamp((Config.API_LAST_UPDATE_TIME)).astimezone(pytz.timezone("America/Los_Angeles"))
+        default_update = datetime.fromtimestamp((Config.API_LAST_UPDATE_TIME))
+        default_update = default_update.astimezone(pytz.timezone("America/Los_Angeles"))
         human_readable_default_update = default_update.strftime('%Y-%m-%d %H:%M')
     except Exception as e:
         logger.exception(type(e).__name__ + ": " + str(e), exc_info=False)


### PR DESCRIPTION
This error was showing up in Logz.io when running in production, but not when running locally: `TypeError: 'datetime.datetime' object cannot be interpreted as an integer`.

![image](https://user-images.githubusercontent.com/1873072/157780151-7bcf3831-5b92-4742-8228-de10f137fb9e.png)

The log notes a file (`./app/main.py`) and line number (`286`).  Upon debugging and using a breakpoint in the `try` statement, I realized the code was indeed throwing an exception.  I un-chained the function calls, changing the code from this:

``` python
default_update = datetime.fromtimestamp((Config.API_LAST_UPDATE_TIME)).astimezone(pytz.timezone("America/Los_Angeles"))
```

to this:

``` python
default_update = datetime.fromtimestamp((Config.API_LAST_UPDATE_TIME))
default_update = default_update.astimezone(pytz.timezone("America/Los_Angeles"))
```

Not sure why running it locally did not trigger a log of this exception in Logz.io.