### PR TITLE
real fix for datetime error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,7 @@ def run_continuously(interval=UPDATE_INTERVAL):
             while not cease_continuous_run.is_set():
                 schedule.run_pending()
                 time.sleep(interval)
-                Config.API_LAST_UPDATE_TIME = datetime.now()
+                Config.API_LAST_UPDATE_TIME = os.path.getmtime(r'app/data/CancelledTripsRT.json')
     continuous_thread = ScheduleThread()
     continuous_thread.start()
     return cease_continuous_run
@@ -280,7 +280,7 @@ def login(request:Request):
 def index(request:Request):
     human_readable_default_update = None
     try:
-        default_update = datetime.fromtimestamp((Config.API_LAST_UPDATE_TIME))
+        default_update = datetime.fromtimestamp(Config.API_LAST_UPDATE_TIME)
         default_update = default_update.astimezone(pytz.timezone("America/Los_Angeles"))
         human_readable_default_update = default_update.strftime('%Y-%m-%d %H:%M')
     except Exception as e:

--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ from pathlib import Path
 
 from logzio.handler import LogzioHandler
 
-UPDATE_INTERVAL = 300
+UPDATE_INTERVAL = 30
 PATH_TO_CALENDAR_JSON = 'app/data/calendar_dates.json'
 PATH_TO_CANCELED_JSON = 'app/data/CancelledTripsRT.json'
 
@@ -65,7 +65,6 @@ def run_continuously(interval=UPDATE_INTERVAL):
             while not cease_continuous_run.is_set():
                 schedule.run_pending()
                 time.sleep(interval)
-                Config.API_LAST_UPDATE_TIME = os.path.getmtime(r'app/data/CancelledTripsRT.json')
     continuous_thread = ScheduleThread()
     continuous_thread.start()
     return cease_continuous_run

--- a/app/update_canceled_trips.py
+++ b/app/update_canceled_trips.py
@@ -13,6 +13,7 @@ def run_update():
         if connect_to_ftp(REMOTEPATH, Config.SERVER, Config.USERNAME, Config.PASS):
             get_file_from_ftp(TARGET_FILE, LOCALPATH)
             # ftp_json_file_time = file_modified_time
+            Config.API_LAST_UPDATE_TIME = os.path.getmtime(LOCALPATH + TARGET_FILE)
         disconnect_from_ftp()
     except Exception as e:
         logger.exception('FTP transfer failed: ' + str(e))


### PR DESCRIPTION
The last attempt at a fix was a fake!

The exception does not trigger within the `index()` function until the first time `run_continuously()` gets called because the problem has to do with `API_LAST_UPDATE_TIME` being updated to the wrong datatype inside that function.  Any attempts to trigger the error before then will not work because the initial value is the correct datatype.

## Problem

`API_LAST_UPDATE_TIME` is initially set in `config.py` using `os.path.getmtime(r'app/main.py')`, which returns a floating point integer value that represents the time in seconds since the _epoch_.

This is correct because we pass that value to `datetime.fromtimestamp()` which takes in timestamp/float datatypes.

The problem inside our `run_continuously()` function is that `API_LAST_UPDATE_TIME` is updated using a call to `datetime.now()`, which returns a datetime object, NOT a timestamp/float.

On all subsequent calls to `index()`, we will get a TypeError from passing a datetime instead of timestamp to `datetime.fromtimestamp()`.

## Solution

To get a timestamp that makes sense for `API_LAST_UPDATE_TIME`, I pulled the last modified time for the `CancelledTripsRT.json` file and moved the call to the `run_update()` function.  This ensures the time is updated based on whether the file is udpated.

This Config variable and implementation may need to be revisited as part of:

- #59
- #60